### PR TITLE
updated dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
   "main": "./lib/index.js",
   "dependencies": {
     "earlgrey-runtime": ">=0.0.11",
-    "inquirer": "^0.11.3"
+    "inquirer": "^1.2.1"
   },
   "devDependencies": {
-    "earlgrey": ">=0.0.13",
-    "mocha": "^2.2.1",
-    "earl-mocha": ">=0.0.3"
+    "earlgrey": "^0.0.14",
+    "mocha": "^3.1.2",
+    "earl-mocha": "^0.0.3"
   },
   "scripts": {
     "refresh": "earl compile -5vso lib/ src/",


### PR DESCRIPTION
Compiles and runs just fine. 

Couldn't run tests with `npm test`since tests are not compiled and apparently are not run by `early-mocha` as they should be?
